### PR TITLE
fix: return types; callback prop types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { useRunInJS } from 'react-native-worklets-core';
 import { scanBarcodes } from './scanBarcodes';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
+export { scanBarcodes } from './scanBarcodes';
+
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;
   // @ts-ignore

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-native-vision-camera';
 import { useRunInJS } from 'react-native-worklets-core';
 import { scanBarcodes } from './scanBarcodes';
-import type { CameraTypes, Frame, FrameProcessor } from './types';
+import type { CameraTypes, Frame, FrameProcessor, BarcodeDataMap } from './types';
 
 export { scanBarcodes } from './scanBarcodes';
 export type { BarcodeData, BarcodeDataMap } from './types'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,18 +8,19 @@ import { scanBarcodes } from './scanBarcodes';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
 export { scanBarcodes } from './scanBarcodes';
+export type { BarcodeData, BarcodeDataMap } from './types'
 
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;
   // @ts-ignore
-  const useWorklets = useRunInJS((data: object): void => {
+  const useWorklets = useRunInJS((data: BarcodeDataMap): void => {
     callback(data);
   }, []);
   const frameProcessor: FrameProcessor = useFrameProcessor(
     (frame: Frame): void => {
       'worklet';
       // @ts-ignore
-      const data: object = scanBarcodes(frame, options);
+      const data = scanBarcodes(frame, options);
       // @ts-ignore
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useWorklets(data);

--- a/src/scanBarcodes.ts
+++ b/src/scanBarcodes.ts
@@ -1,4 +1,4 @@
-import type { Frame, FrameProcessorPlugin, ScanBarcodeOptions } from './types';
+import type { Frame, FrameProcessorPlugin, ScanBarcodeOptions, BarcodeDataMap } from './types';
 import { VisionCameraProxy } from 'react-native-vision-camera';
 import { Platform } from 'react-native';
 
@@ -11,7 +11,7 @@ const LINKING_ERROR: string =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-export function scanBarcodes(frame: Frame, options: ScanBarcodeOptions): any {
+export function scanBarcodes(frame: Frame, options: ScanBarcodeOptions): BarcodeDataMap {
   'worklet';
   if (plugin == null) throw new Error(LINKING_ERROR);
   // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,21 @@ export interface ScanBarcodeOptions {
     | 'upc-a';
 }
 
+export interface BarcodeData {
+  bottom: number
+  height: number
+  left: number
+  rawValue: string
+  right: number
+  top: number
+  width: number
+}
+
+export interface BarcodeDataMap {
+  [key: number]: BarcodeData
+}
+
 export type CameraTypes = {
-  callback: Function;
+  callback: (data: BarcodeDataMap) => void;
   options: ScanBarcodeOptions;
 } & CameraProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface ScanBarcodeOptions {
     | 'upc-a';
 }
 
-export interface BarcodeData {
+export type BarcodeData = {
   bottom: number
   height: number
   left: number
@@ -32,7 +32,7 @@ export interface BarcodeData {
   width: number
 }
 
-export interface BarcodeDataMap {
+export type BarcodeDataMap = {
   [key: number]: BarcodeData
 }
 


### PR DESCRIPTION
Adds types for the result/return of `scanBarcodes`
Replaces the current return type of the function with `BarcodeDataMap` interface

#### before
```ts
const data: object = scanBarcodes(frame, options);
```

#### after
```ts
export interface BarcodeData {
  bottom: number
  height: number
  left: number
  rawValue: string
  right: number
  top: number
  width: number
}

export interface BarcodeDataMap {
  [key: number]: BarcodeData
}
```

```ts
const data = scanBarcodes(frame, options);
```

Adds `BarcodeDataMap` in `callback`

```ts
export type CameraTypes = {
  callback: (data: BarcodeDataMap) => void;
  options: ScanBarcodeOptions;
} & CameraProps;
```

#### usage
```tsx
       callback={(data) => {
            const map: Map<string, typeof data> = new Map(Object.entries(data))
            const result = map.get('0')
            console.log(result)
          }}
```