### PR TITLE
fix(Android): upgrade react-native-vision-camera v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ android/keystores/debug.keystore
 .yarnrc.yml
 .yarn
 yarn.lock
+.pnp/
+.pnp.*
 # Expo
 .expo/
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,13 @@ android/keystores/debug.keystore
 !.yarn/versions
 .yarnrc.yml
 .yarn
-yarn.lock
 .pnp/
 .pnp.*
+
+# Lockfiles
+yarn.lock
+package-lock.json
+
 # Expo
 .expo/
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,5 +92,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.google.mlkit:barcode-scanning:17.2.0'
   implementation project(':react-native-vision-camera')
+  implementation "androidx.camera:camera-core:1.1.0"
 }
 

--- a/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
+++ b/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
@@ -23,10 +23,9 @@ import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_E
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13
 import com.google.mlkit.vision.common.InputImage
-import com.mrousavy.camera.frameprocessor.Frame
-import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
-import com.mrousavy.camera.frameprocessor.VisionCameraProxy
-import com.mrousavy.camera.types.Orientation
+import com.mrousavy.camera.frameprocessors.Frame
+import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
+import com.mrousavy.camera.frameprocessors.VisionCameraProxy
 
 class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map<String, Any>?): FrameProcessorPlugin() {
 
@@ -49,11 +48,9 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
       else if (arguments?.get("all").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_ALL_FORMATS)
       else optionsBuilder.setBarcodeFormats(FORMAT_ALL_FORMATS)
 
-       val scanner = BarcodeScanning.getClient(optionsBuilder.build())
+      val scanner = BarcodeScanning.getClient(optionsBuilder.build())
       val mediaImage: Image = frame.image
-      val orientation: Orientation = frame.orientation
-
-      val image = InputImage.fromMediaImage(mediaImage, orientation.toDegrees())
+      val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
       val task: Task<List<Barcode>> = scanner.process(image)
       val barcodes: List<Barcode> = Tasks.await(task)
       val array = WritableNativeArray()

--- a/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerPackage.kt
+++ b/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerPackage.kt
@@ -4,8 +4,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
-import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry
-
+import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
 
 class VisionCameraV3BarcodeScannerPackage : ReactPackage {
   companion object {
@@ -18,9 +17,7 @@ class VisionCameraV3BarcodeScannerPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     return emptyList()
   }
-
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
     return emptyList()
   }
-
 }

--- a/ios/VisionCameraV3BarcodeScanner.m
+++ b/ios/VisionCameraV3BarcodeScanner.m
@@ -2,8 +2,8 @@
 #import <MLKitBarcodeScanning/MLKBarcodeScannerOptions.h>
 #import <VisionCamera/FrameProcessorPlugin.h>
 #import <VisionCamera/FrameProcessorPluginRegistry.h>
-#import <VisionCamera/VisionCameraProxy.h>
 #import <VisionCamera/Frame.h>
+#import <React/RCTBridgeModule.h>
 @import MLKitVision;
 
 @interface VisionCameraV3BarcodeScannerPlugin : FrameProcessorPlugin

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-builder-bob": "^0.20.0",
-    "react-native-vision-camera": "3.9.1",
-    "react-native-worklets-core": "0.4.0",
+    "react-native-vision-camera": "^4.0.1",
+    "react-native-worklets-core": "^1.1.1",
     "release-it": "^15.0.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { scanBarcodes } from './scanBarcodes';
 import type {
   CameraTypes,
   Frame,
-  FrameProcessor,
+  ReadonlyFrameProcessor,
   BarcodeDataMap,
 } from './types';
 
@@ -24,7 +24,7 @@ export const Camera = forwardRef(function Camera(
   const useWorklets = useRunInJS((data: BarcodeDataMap): void => {
     callback(data);
   }, []);
-  const frameProcessor: FrameProcessor = useFrameProcessor(
+  const frameProcessor: ReadonlyFrameProcessor = useFrameProcessor(
     (frame: Frame): void => {
       'worklet';
       // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { CameraProps } from 'react-native-vision-camera';
 export type {
   Frame,
-  FrameProcessor,
+  ReadonlyFrameProcessor,
   FrameProcessorPlugin,
 } from 'react-native-vision-camera';
 export interface ScanBarcodeOptions {


### PR DESCRIPTION
# Fix Android support for `react-native-vision-camera` release [v4.0.0](https://github.com/mrousavy/react-native-vision-camera/releases/tag/v4.0.0)

- [changelog](https://github.com/mrousavy/react-native-vision-camera/compare/v3.9.2...v4.0.0)

> [!CAUTION]
> This will break in `react-native-vision` releases before v4.0.0

## Upgrade

### Dependencies
```json
    "react-native-vision-camera": "3.9.1",
    "react-native-worklets-core": "0.4.0",
```
```json
    "react-native-vision-camera": "^4.0.1",
    "react-native-worklets-core": "^1.1.1",
```

## Fix 

### `com.mrousavy.camera.frameprocessor` imports

```kt
import com.mrousavy.camera.frameprocessor.Frame
import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
import com.mrousavy.camera.frameprocessor.VisionCameraProxy
```

```kt
import com.mrousavy.camera.frameprocessors.Frame
import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
import com.mrousavy.camera.frameprocessors.VisionCameraProxy
```

### `toDegrees()` method

`orientation.toDegrees()` was removed in v4

```kt
val image = InputImage.fromMediaImage(mediaImage, orientation.toDegrees())
```

```kt
val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
```

### type `FrameProcessor`

type FrameProcessor was replaced with ReadonlyFrameProcessor