### PR TITLE
fix(CodeTypes): allow the use of multiple code types

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,8 +90,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.mlkit:barcode-scanning:17.2.0'
   implementation project(':react-native-vision-camera')
+  implementation 'com.google.mlkit:barcode-scanning:17.2.0'
   implementation "androidx.camera:camera-core:1.1.0"
 }
-

--- a/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
+++ b/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
@@ -8,92 +8,110 @@ import com.google.android.gms.tasks.Tasks
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UNKNOWN
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ALL_FORMATS
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_AZTEC
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODABAR
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_128
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_39
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODE_93
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_CODABAR
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_DATA_MATRIX
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_ITF
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_PDF417
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_QR_CODE
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_A
 import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_UPC_E
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_8
-import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_EAN_13
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_PDF417
+import com.google.mlkit.vision.barcode.common.Barcode.FORMAT_AZTEC
 import com.google.mlkit.vision.common.InputImage
 import com.mrousavy.camera.frameprocessors.Frame
 import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
 import com.mrousavy.camera.frameprocessors.VisionCameraProxy
 
 class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map<String, Any>?): FrameProcessorPlugin() {
+    private var optionsBuilder = BarcodeScannerOptions.Builder()
 
-  override fun callback(frame: Frame, arguments: Map<String, Any>?): Any {
-    try {
-      val optionsBuilder = BarcodeScannerOptions.Builder()
-
-      if (arguments?.get("code-128").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_128)
-      else if (arguments?.get("code-39").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_39)
-      else if (arguments?.get("code-93").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_93)
-      else if (arguments?.get("codabar").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODABAR)
-      else if (arguments?.get("ean-13").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_EAN_13)
-      else if (arguments?.get("ean-8").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_EAN_8)
-      else if (arguments?.get("itf").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_ITF)
-      else if (arguments?.get("upc-e").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_UPC_E)
-      else if (arguments?.get("upc-a").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_UPC_A)
-      else if (arguments?.get("qr").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_QR_CODE)
-      else if (arguments?.get("pdf-417").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_PDF417)
-      else if (arguments?.get("aztec").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_AZTEC)
-      else if (arguments?.get("data-matrix").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_DATA_MATRIX)
-      else if (arguments?.get("all").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_ALL_FORMATS)
-      else optionsBuilder.setBarcodeFormats(FORMAT_ALL_FORMATS)
-
-      val scanner = BarcodeScanning.getClient(optionsBuilder.build())
-      val mediaImage: Image = frame.image
-      val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
-      val task: Task<List<Barcode>> = scanner.process(image)
-      val barcodes: List<Barcode> = Tasks.await(task)
-      val array = WritableNativeArray()
-
-      for (barcode in barcodes) {
-        val map = WritableNativeMap()
-        val bounds = barcode.boundingBox
-
-        if (bounds != null) {
-          map.putInt("width",bounds.width())
-          map.putInt("height",bounds.height())
-          map.putInt("top",bounds.top)
-          map.putInt("bottom",bounds.bottom)
-          map.putInt("left",bounds.left)
-          map.putInt("right",bounds.right)
-        }
-
-        val rawValue = barcode.rawValue
-        map.putString("rawValue",rawValue)
-        val valueType = barcode.valueType
-
-        when (valueType) {
-          Barcode.TYPE_WIFI -> {
-            val ssid = barcode.wifi!!.ssid
-            map.putString("ssid",ssid)
-            val password = barcode.wifi!!.password
-            map.putString("password",password)
-          }
-          Barcode.TYPE_URL -> {
-            val title = barcode.url!!.title
-            map.putString("title",title)
-            val url = barcode.url!!.url
-            map.putString("url",url)
-          }
-        }
-
-        array.pushMap(map)
-      }
-
-      return array.toArrayList()
-    } catch (e: Exception) {
-       throw  Exception("Error processing barcode scanner: $e ")
+    init {
+        this.setCodeTypes(options)
     }
-  }
+
+    override fun callback(frame: Frame, arguments: Map<String, Any>?): Any {
+        try {
+            setCodeTypes(arguments)
+
+            val scanner = BarcodeScanning.getClient(this.optionsBuilder.build())
+            val mediaImage: Image = frame.image
+            val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
+            val task: Task<List<Barcode>> = scanner.process(image)
+            val barcodes: List<Barcode> = Tasks.await(task)
+            val array = WritableNativeArray()
+
+            for (barcode in barcodes) {
+                val map = WritableNativeMap()
+                val bounds = barcode.boundingBox
+
+                if (bounds != null) {
+                    map.putInt("width",bounds.width())
+                    map.putInt("height",bounds.height())
+                    map.putInt("top",bounds.top)
+                    map.putInt("bottom",bounds.bottom)
+                    map.putInt("left",bounds.left)
+                    map.putInt("right",bounds.right)
+                }
+
+                val rawValue = barcode.rawValue
+                map.putString("rawValue",rawValue)
+                val valueType = barcode.valueType
+
+                when (valueType) {
+                    Barcode.TYPE_WIFI -> {
+                        val ssid = barcode.wifi!!.ssid
+                        map.putString("ssid",ssid)
+                        val password = barcode.wifi!!.password
+                        map.putString("password",password)
+                    }
+                    Barcode.TYPE_URL -> {
+                        val title = barcode.url!!.title
+                        map.putString("title",title)
+                        val url = barcode.url!!.url
+                        map.putString("url",url)
+                    }
+                }
+
+                array.pushMap(map)
+            }
+
+            return array.toArrayList()
+        } catch (e: Exception) {
+            throw  Exception("Error processing barcode scanner: $e ")
+        }
+    }
+
+    private fun setCodeTypes(rawArguments: Map<String, Any>?) {
+        val codeTypes = rawArguments?.get("codeTypes") as? List<String> ?: listOf("all_formats")
+        var formats = 0
+
+        for (codeType in codeTypes) {
+            formats = formats or when (codeType) {
+                "unknown" -> FORMAT_UNKNOWN
+                "all_formats" -> FORMAT_ALL_FORMATS
+                "code_128" -> FORMAT_CODE_128
+                "code_39" -> FORMAT_CODE_39
+                "code_93" -> FORMAT_CODE_93
+                "codabar" -> FORMAT_CODABAR
+                "data_matrix" -> FORMAT_DATA_MATRIX
+                "ean_13" -> FORMAT_EAN_13
+                "ean_8" -> FORMAT_EAN_8
+                "itf" -> FORMAT_ITF
+                "qr_code" -> FORMAT_QR_CODE
+                "upc_a" -> FORMAT_UPC_A
+                "upc_e" -> FORMAT_UPC_E
+                "pdf417" -> FORMAT_PDF417
+                "aztec" -> FORMAT_AZTEC
+                else -> 0
+            }
+        }
+
+        this.optionsBuilder.setBarcodeFormats(formats)
+    }
 }

--- a/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
+++ b/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
@@ -31,7 +31,8 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
 
   override fun callback(frame: Frame, arguments: Map<String, Any>?): Any {
     try {
-     val optionsBuilder = BarcodeScannerOptions.Builder()
+      val optionsBuilder = BarcodeScannerOptions.Builder()
+
       if (arguments?.get("code-128").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_128)
       else if (arguments?.get("code-39").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_39)
       else if (arguments?.get("code-93").toString().toBoolean()) optionsBuilder.setBarcodeFormats(FORMAT_CODE_93)
@@ -54,9 +55,11 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
       val task: Task<List<Barcode>> = scanner.process(image)
       val barcodes: List<Barcode> = Tasks.await(task)
       val array = WritableNativeArray()
+
       for (barcode in barcodes) {
         val map = WritableNativeMap()
         val bounds = barcode.boundingBox
+
         if (bounds != null) {
           map.putInt("width",bounds.width())
           map.putInt("height",bounds.height())
@@ -65,9 +68,11 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
           map.putInt("left",bounds.left)
           map.putInt("right",bounds.right)
         }
+
         val rawValue = barcode.rawValue
         map.putString("rawValue",rawValue)
         val valueType = barcode.valueType
+
         when (valueType) {
           Barcode.TYPE_WIFI -> {
             val ssid = barcode.wifi!!.ssid
@@ -82,12 +87,13 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
             map.putString("url",url)
           }
         }
+
         array.pushMap(map)
       }
+
       return array.toArrayList()
     } catch (e: Exception) {
        throw  Exception("Error processing barcode scanner: $e ")
     }
   }
-
 }

--- a/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
+++ b/android/src/main/java/com/visioncamerav3barcodescanner/VisionCameraV3BarcodeScannerModule.kt
@@ -28,7 +28,7 @@ import com.mrousavy.camera.frameprocessors.Frame
 import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
 import com.mrousavy.camera.frameprocessors.VisionCameraProxy
 
-class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map<String, Any>?): FrameProcessorPlugin() {
+class VisionCameraV3BarcodeScannerModule(proxy: VisionCameraProxy, options: Map<String, Any>?): FrameProcessorPlugin() {
     private var optionsBuilder = BarcodeScannerOptions.Builder()
 
     init {
@@ -37,7 +37,9 @@ class VisionCameraV3BarcodeScannerModule(proxy : VisionCameraProxy, options: Map
 
     override fun callback(frame: Frame, arguments: Map<String, Any>?): Any {
         try {
-            setCodeTypes(arguments)
+            if (arguments != null && arguments.containsKey("codeTypes")) {
+                setCodeTypes(arguments)
+            }
 
             val scanner = BarcodeScanning.getClient(this.optionsBuilder.build())
             val mediaImage: Image = frame.image

--- a/ios/VisionCameraV3BarcodeScanner.m
+++ b/ios/VisionCameraV3BarcodeScanner.m
@@ -16,43 +16,14 @@
 - (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder*)proxy
                            withOptions:(NSDictionary* _Nullable)options {
     self = [super initWithProxy:proxy withOptions:options];
-
+    [self setCodeTypes:options];
     return self;
 }
 
 - (id _Nullable)callback:(Frame* _Nonnull)frame
            withArguments:(NSDictionary* _Nullable)arguments {
-    options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatAll)];
-
-    if (arguments != nil && [arguments.allKeys containsObject:@"codeType"]) {
-        NSString *codeType = arguments[@"codeType"];
-        if ([codeType  isEqual: @"code-128"]) {
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatCode128)];
-        } else if ([codeType  isEqual: @"code-39"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatCode39)];
-        } else if ([codeType  isEqual: @"code-93"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatCode93)];
-        } else if ([codeType  isEqual: @"codabar"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatCodaBar)];
-        } else if ([codeType  isEqual: @"ean-13"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatEAN13)];
-        } else if ([codeType  isEqual: @"ean-8"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatEAN8)];
-        } else if ([codeType  isEqual: @"itf"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatITF)];
-        } else if ([codeType  isEqual: @"upc-e"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatUPCE)];
-        } else if ([codeType  isEqual: @"upc-a"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatUPCA)];
-        } else if ([codeType  isEqual: @"qr"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatQRCode)];
-        } else if ([codeType  isEqual: @"pdf-417"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatPDF417)];
-        } else if ([codeType  isEqual: @"aztec"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatAztec)];
-        } else if ([codeType isEqual:@"all"]){
-            options = [[MLKBarcodeScannerOptions alloc] initWithFormats:(MLKBarcodeFormatAll)];
-        }
+    if (arguments != nil && [arguments.allKeys containsObject:@"codeTypes"]) {
+        [self setCodeTypes:arguments];
     }
 
     MLKBarcodeScanner *barcodeScanner = [MLKBarcodeScanner barcodeScannerWithOptions:options];
@@ -113,6 +84,53 @@
 
     dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
     return data;
+}
+
+- (void)setCodeTypes:(NSDictionary* _Nullable)rawArguments {
+    NSArray *codeTypes = rawArguments[@"codeTypes"] ?: @[@"all_formats"];
+    MLKBarcodeFormat formats = MLKBarcodeFormatAll;
+
+    for (NSString *codeType in codeTypes) {
+        formats = formats | [self barcodeFormatForString:codeType];
+    }
+
+    options = [[MLKBarcodeScannerOptions alloc] initWithFormats:formats];
+}
+
+- (MLKBarcodeFormat)barcodeFormatForString:(NSString *)string {
+    if ([string isEqualToString:@"unknown"]) {
+        return MLKBarcodeFormatUnknown;
+    } else if ([string isEqualToString:@"all_formats"]) {
+        return MLKBarcodeFormatAll;
+    } else if ([string isEqualToString:@"code_128"]) {
+        return MLKBarcodeFormatCode128;
+    } else if ([string isEqualToString:@"code_39"]) {
+        return MLKBarcodeFormatCode39;
+    } else if ([string isEqualToString:@"code_93"]) {
+        return MLKBarcodeFormatCode93;
+    } else if ([string isEqualToString:@"codabar"]) {
+        return MLKBarcodeFormatCodaBar;
+    } else if ([string isEqualToString:@"data_matrix"]) {
+        return MLKBarcodeFormatDataMatrix;
+    } else if ([string isEqualToString:@"ean_13"]) {
+        return MLKBarcodeFormatEAN13;
+    } else if ([string isEqualToString:@"ean_8"]) {
+        return MLKBarcodeFormatEAN8;
+    } else if ([string isEqualToString:@"itf"]) {
+        return MLKBarcodeFormatITF;
+    } else if ([string isEqualToString:@"qr_code"]) {
+        return MLKBarcodeFormatQRCode;
+    } else if ([string isEqualToString:@"upc_a"]) {
+        return MLKBarcodeFormatUPCA;
+    } else if ([string isEqualToString:@"upc_e"]) {
+        return MLKBarcodeFormatUPCE;
+    } else if ([string isEqualToString:@"pdf417"]) {
+        return MLKBarcodeFormatPDF417;
+    } else if ([string isEqualToString:@"aztec"]) {
+        return MLKBarcodeFormatAztec;
+    } else {
+        return 0;
+    }
 }
 
 VISION_EXPORT_FRAME_PROCESSOR(VisionCameraV3BarcodeScannerPlugin, scanBarcodes)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ export * from './types';
  *
  * @example
  * ```tsx
- * <Camera device={device} callback={handleBarcode} options={{ codeTypes: ['all'] }} />
+ * <Camera device={device} callback={handleBarcode} options={{ codeTypes: ['all_formats'] }} />
  * ```
  */
 export const Camera = forwardRef(function Camera(
@@ -81,14 +81,14 @@ export const Camera = forwardRef(function Camera(
  *
  * @example
  * ```tsx
- * const { scanBarcodes } = useBarcodeScannerPlugin({ codeTypes: ['all'] });
+ * const { scanBarcodes } = useBarcodeScannerPlugin({ codeTypes: ['all_formats'] });
  * ```
  */
 export function useBarcodeScannerPlugin(
   options?: BarcodeScannerOptions
 ): BarcodeScannerPlugin {
   return useMemo(
-    () => createBarcodeScannerPlugin(options ?? { codeTypes: ['all'] }),
+    () => createBarcodeScannerPlugin(options ?? { codeTypes: ['all_formats'] }),
     [options]
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,61 +3,92 @@ import {
   Camera as VisionCamera,
   useFrameProcessor,
 } from 'react-native-vision-camera';
+import { useRunOnJS } from 'react-native-worklets-core';
 import { createBarcodeScannerPlugin } from './scanBarcodes';
 import type {
-  ReadonlyFrameProcessor,
-  Frame,
+  BarcodeData,
+  BarcodeScannerOptions,
+  BarcodeScannerPlugin,
   CameraTypes,
   ForwardedRef,
-  Barcode,
-  BarcodeScannerPlugin,
-  ScanBarcodeOptions,
+  Frame,
+  ReadonlyFrameProcessor,
 } from './types';
-import { useRunOnJS } from 'react-native-worklets-core';
 
+export { scanBarcodes } from './scanBarcodes';
+export * from './types';
+
+/**
+ * `Camera` is a component that wraps the {@link VisionCamera} from 'react-native-vision-camera'.
+ * It uses the {@link useBarcodeScannerPlugin} hook to scan barcodes from the camera feed.
+ *
+ * @param device The device to use for the camera.
+ * @param callback The function to call when a barcode is scanned.
+ * @param options The options for the barcode scanner.
+ * @param props The rest of the props to pass to the VisionCamera component.
+ * @param ref The ref to forward to the VisionCamera component.
+ *
+ * @example
+ * ```tsx
+ * <Camera device={device} callback={handleBarcode} options={{ codeTypes: ['all'] }} />
+ * ```
+ */
 export const Camera = forwardRef(function Camera(
-  props: CameraTypes,
+  { device, callback, options, ...props }: CameraTypes,
   ref: ForwardedRef<any>
 ) {
-  const { device, callback, options = {}, ...p } = props;
-  // @ts-ignore
-  const { scanBarcodes } = useBarcodeScanner(options);
+  const { scanBarcodes } = useBarcodeScannerPlugin(options);
+
   const useWorklets = useRunOnJS(
-    (data: Barcode): void => {
+    (data: BarcodeData): void => {
       callback(data);
     },
     [options]
   );
+
   const frameProcessor: ReadonlyFrameProcessor = useFrameProcessor(
     (frame: Frame) => {
       'worklet';
-      const data: Barcode = scanBarcodes(frame);
+      const data: BarcodeData = scanBarcodes(frame);
       // @ts-ignore
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useWorklets(data);
     },
     []
   );
+
   return (
     <>
       {!!device && (
         <VisionCamera
-          pixelFormat="yuv"
           ref={ref}
-          frameProcessor={frameProcessor}
           device={device}
-          {...p}
+          pixelFormat="yuv"
+          frameProcessor={frameProcessor}
+          {...props}
         />
       )}
     </>
   );
 });
 
-export function useBarcodeScanner(
-  options?: ScanBarcodeOptions
+/**
+ * `useBarcodeScannerPlugin` is a hook that creates a barcode scanner plugin with the given options.
+ *
+ * @param options The options for the barcode scanner.
+ *
+ * @returns An object with a `scanBarcodes` function that can be used to scan barcodes from a given frame.
+ *
+ * @example
+ * ```tsx
+ * const { scanBarcodes } = useBarcodeScannerPlugin({ codeTypes: ['all'] });
+ * ```
+ */
+export function useBarcodeScannerPlugin(
+  options?: BarcodeScannerOptions
 ): BarcodeScannerPlugin {
   return useMemo(
-    () => createBarcodeScannerPlugin(options || ['all']),
+    () => createBarcodeScannerPlugin(options ?? { codeTypes: ['all'] }),
     [options]
   );
 }

--- a/src/scanBarcodes.ts
+++ b/src/scanBarcodes.ts
@@ -25,7 +25,7 @@ const LINKING_ERROR: string =
  *
  * @example
  * ```ts
- * const barcodeScannerPlugin = createBarcodeScannerPlugin({ codeTypes: ['all'] });
+ * const barcodeScannerPlugin = createBarcodeScannerPlugin({ codeTypes: ['all_formats'] });
  * const frameProcessor = useFrameProcessor((frame) => {
  *   'worklet'
  *   runAsync(frame, () => {
@@ -73,7 +73,7 @@ const plugin: FrameProcessorPlugin | undefined =
  *   'worklet'
  *   runAsync(frame, () => {
  *     'worklet'
- *     const data = scanBarcodes(frame, { codeTypes: ['all'] })
+ *     const data = scanBarcodes(frame, { codeTypes: ['all_formats'] })
  *     console.log(data)
  *   })
  * }, [])

--- a/src/scanBarcodes.ts
+++ b/src/scanBarcodes.ts
@@ -58,7 +58,7 @@ const plugin: FrameProcessorPlugin | undefined =
 /**
  * Scans barcodes from a given frame.
  *
- * Note: This function has been deprecated. Use {@link createBarcodeScannerPlugin} instead.
+ * Note: Use {@link createBarcodeScannerPlugin} instead.
  *
  * @param frame The frame to scan for barcodes.
  * @param options The options for the barcode scanner.
@@ -78,8 +78,6 @@ const plugin: FrameProcessorPlugin | undefined =
  *   })
  * }, [])
  * ```
- *
- * @deprecated
  */
 export function scanBarcodes(
   frame: Frame,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,21 +7,43 @@ export type {
   ReadonlyFrameProcessor,
 } from 'react-native-vision-camera';
 
+/** CodeTypes from Google's MLkit */
+/**
+ * @example
+ * ```
+ * "unknown" -> FORMAT_UNKNOWN
+ * "all_formats" -> FORMAT_ALL_FORMATS
+ * "code_128" -> FORMAT_CODE_128
+ * "code_39" -> FORMAT_CODE_39
+ * "code_93" -> FORMAT_CODE_93
+ * "codabar" -> FORMAT_CODABAR
+ * "data_matrix" -> FORMAT_DATA_MATRIX
+ * "ean_13" -> FORMAT_EAN_13
+ * "ean_8" -> FORMAT_EAN_8
+ * "itf" -> FORMAT_ITF
+ * "qr_code" -> FORMAT_QR_CODE
+ * "upc_a" -> FORMAT_UPC_A
+ * "upc_e" -> FORMAT_UPC_E
+ * "pdf417" -> FORMAT_PDF417
+ * "aztec" -> FORMAT_AZTEC
+ * ```
+ */
 export type CodeType =
-  | 'aztec'
-  | 'code128'
-  | 'code39'
-  | 'code39mod43'
-  | 'code93'
-  | 'ean13'
-  | 'ean8'
-  | 'pdf417'
-  | 'qr'
+  | 'unknown'
+  | 'all_formats'
+  | 'code_128'
+  | 'code_39'
+  | 'code_93'
+  | 'codabar'
+  | 'data_matrix'
+  | 'ean_13'
+  | 'ean_8'
+  | 'itf'
+  | 'qr_code'
+  | 'upc_a'
   | 'upc_e'
-  | 'interleaved2of5'
-  | 'itf14'
-  | 'datamatrix'
-  | 'all';
+  | 'pdf417'
+  | 'aztec';
 
 export type BarcodeScannerOptions = {
   codeTypes: CodeType[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,9 @@ export type {
   ReadonlyFrameProcessor,
 } from 'react-native-vision-camera';
 
-/** CodeTypes from Google's MLkit */
 /**
+ * CodeTypes from Google's MLkit
+ *
  * @example
  * ```
  * "unknown" -> FORMAT_UNKNOWN
@@ -69,5 +70,26 @@ export type CameraTypes = {
 } & CameraProps;
 
 export type BarcodeScannerPlugin = {
+  /**
+   * Scans barcodes from a given frame.
+   *
+   * @param frame The frame to scan for barcodes.
+   *
+   * @throws {Error} If the frame processor plugin is not initialized.
+   *
+   * @returns The scanned barcode data.
+   *
+   * @example
+   * ```ts
+   * const frameProcessor = useFrameProcessor((frame) => {
+   *   'worklet'
+   *   runAsync(frame, () => {
+   *     'worklet'
+   *     const data = scanBarcodes(frame)
+   *     console.log(data)
+   *   })
+   * }, [])
+   * ```
+   */
   scanBarcodes: (frame: Frame) => BarcodeData;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,32 +1,33 @@
-import type { CameraProps } from 'react-native-vision-camera';
+import type { CameraProps, Frame } from 'react-native-vision-camera';
+
+export type { ForwardedRef } from 'react';
 export type {
   Frame,
-  ReadonlyFrameProcessor,
   FrameProcessorPlugin,
+  ReadonlyFrameProcessor,
 } from 'react-native-vision-camera';
-import type { Frame } from 'react-native-vision-camera';
-export type { ForwardedRef } from 'react';
 
-type BarCodeType = Readonly<{
-  aztec: any;
-  code128: any;
-  code39: any;
-  code39mod43: any;
-  code93: any;
-  ean13: any;
-  ean8: any;
-  pdf417: any;
-  qr: any;
-  upc_e: any;
-  interleaved2of5: any;
-  itf14: any;
-  datamatrix: any;
-  all: any;
-}>;
+export type CodeType =
+  | 'aztec'
+  | 'code128'
+  | 'code39'
+  | 'code39mod43'
+  | 'code93'
+  | 'ean13'
+  | 'ean8'
+  | 'pdf417'
+  | 'qr'
+  | 'upc_e'
+  | 'interleaved2of5'
+  | 'itf14'
+  | 'datamatrix'
+  | 'all';
 
-export type ScanBarcodeOptions = Array<keyof BarCodeType>;
+export type BarcodeScannerOptions = {
+  codeTypes: CodeType[];
+};
 
-export type Barcode = {
+export type BarcodeInnerData = {
   bottom: number;
   height: number;
   left: number;
@@ -37,14 +38,14 @@ export type Barcode = {
 };
 
 export type BarcodeData = {
-  [key: number]: Barcode;
+  [key: number]: BarcodeInnerData;
 };
 
 export type CameraTypes = {
   callback: (data: BarcodeData) => void;
-  options: ScanBarcodeOptions;
+  options: BarcodeScannerOptions;
 } & CameraProps;
 
 export type BarcodeScannerPlugin = {
-  scanBarcodes: (frame: Frame) => Barcode;
+  scanBarcodes: (frame: Frame) => BarcodeData;
 };


### PR DESCRIPTION
# Fix Options `CodeTypes`

> [!WARNING]  
> Im still testing on iOS

## Changelog
- Allows the user to pick the code type for the barcode scanner, following options avaliable in [MLkit docs](https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/package-summary)
- Refactor types declarations + exports types
- Restore `scanBarcodes`
- Add JDocs
- Fix invalids Code Types
- Code Types can now be set in constructor or in callback, writing it in callback override the value set in the constructor
this is done so, it can be used both in  `scanBarcodes` and `useBarcodeScannerPlugin`

### New Code Types
```ts
/** CodeTypes from Google's MLkit */
/**
 * @example
 * ```
 * "unknown" -> FORMAT_UNKNOWN
 * "all_formats" -> FORMAT_ALL_FORMATS
 * "code_128" -> FORMAT_CODE_128
 * "code_39" -> FORMAT_CODE_39
 * "code_93" -> FORMAT_CODE_93
 * "codabar" -> FORMAT_CODABAR
 * "data_matrix" -> FORMAT_DATA_MATRIX
 * "ean_13" -> FORMAT_EAN_13
 * "ean_8" -> FORMAT_EAN_8
 * "itf" -> FORMAT_ITF
 * "qr_code" -> FORMAT_QR_CODE
 * "upc_a" -> FORMAT_UPC_A
 * "upc_e" -> FORMAT_UPC_E
 * "pdf417" -> FORMAT_PDF417
 * "aztec" -> FORMAT_AZTEC
 * ```
 */
export type CodeType =
  | 'unknown'
  | 'all_formats'
  | 'code_128'
  | 'code_39'
  | 'code_93'
  | 'codabar'
  | 'data_matrix'
  | 'ean_13'
  | 'ean_8'
  | 'itf'
  | 'qr_code'
  | 'upc_a'
  | 'upc_e'
  | 'pdf417'
  | 'aztec';
  ```
  
  ### Usage
  
  ```tsx
    const {scanBarcodes} = useBarcodeScannerPlugin({
    codeTypes: ['code_128', 'qr_code']
  })

  const frameProcessor = useFrameProcessor((frame) => {
    'worklet'
    runAtTargetFps(5, () => {
      'worklet'
      const data = scanBarcodes(frame)
      console.log(data)
    })
  }, [])
  ```